### PR TITLE
Pagination for kaminari objects

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,7 @@
 AllCops:
   TargetRubyVersion: 2.5
+
+Metrics/BlockLength:
+  Exclude:
+    - 'Gemfile'
+    - 'spec/**/*.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,87 @@
 AllCops:
   TargetRubyVersion: 2.5
+  Exclude:
+    - "bin/**/*"
+    - "db/**/*"
+    - "engines/*/db/**/*"
+    - "engines/*/spec/test_app/**/*"
 
 Metrics/BlockLength:
   Exclude:
     - 'Gemfile'
     - 'spec/**/*.rb'
+
+Style/Documentation:
+  Enabled: false
+
+LineLength:
+   Max: 120
+
+Rails:
+  Enabled: true
+
+Layout/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Style/Lambda:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: "double_quotes"
+
+Style/NumericPredicate:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+# Removing Blocks Cop for RSpec so we can do expect { ... }
+Style/BlockDelimiters:
+  Exclude:
+    - 'spec/**/*'
+
+Style/SymbolArray:
+  Enabled: false
+
+# DSLs are allowed long blocks.
+Metrics/BlockLength:
+  Enabled: false
+
+Rails/HttpPositionalArguments:
+  Enabled: false
+
+Style/TrailingCommaInLiteral:
+  Enabled: false
+
+Rails/SkipsModelValidations:
+  Enabled: false
+
+# Can remove when bbatsov/rubocop#4189 is released
+Lint/AmbiguousBlockAssociation:
+  Enabled: false
+
+# Let us line up case/if statements how we want
+Lint/EndAlignment:
+    Enabled: false
+
+Layout/CaseIndentation:
+  Enabled: false
+
+# This is buggy https://github.com/bbatsov/rubocop/issues/4321
+Style/RedundantSelf:
+  Enabled: false
+
+Rails/DynamicFindBy:
+  Whitelist:
+    - find_by_database
+    - find_by_cache
+    - find_by_number
+
+Security/YAMLLoad:
+  Enabled: false
+
+Layout/AlignHash:
+  EnforcedLastArgumentHashStyle: ignore_implicit

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,6 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in grape-swagger-jsonapi-resources.gemspec
+gem 'byebug'
+
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,5 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in grape-swagger-jsonapi-resources.gemspec
-gem 'byebug'
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in grape-swagger-jsonapi-resources.gemspec
-
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,4 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/grape-swagger-jsonapi-resources.gemspec
+++ b/grape-swagger-jsonapi-resources.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "kaminari"
 end

--- a/grape-swagger-jsonapi-resources.gemspec
+++ b/grape-swagger-jsonapi-resources.gemspec
@@ -9,12 +9,12 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Matt Gibson"]
 
   spec.summary       = <<~TEXT
-                         This gem will allow you to use JSONAPI::Resources resource definition classes with Grape
-                         and have the correct Swagger docs generated from them.
+    This gem will allow you to use JSONAPI::Resources resource definition classes with Grape
+    and have the correct Swagger docs generated from them.
                        TEXT
   spec.description   = <<~TEXT
-                         The use case is that you are using the Grape gem to define your API, want to use JSONAPI,
-                         and want to have Swagger docs for the endpoints.
+    The use case is that you are using the Grape gem to define your API, want to use JSONAPI,
+    and want to have Swagger docs for the endpoints.
                        TEXT
   spec.homepage      = "https://github.com/mattgibson/grape-swagger-jsonapi-resources"
   spec.license       = "MIT"
@@ -26,16 +26,16 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rails", ">= 4.2" # jsonapi-resources needs this but doesn't declare it
   spec.add_dependency "grape", "~> 1.0"
+  spec.add_dependency "grape-jsonapi-resources", "~> 0.0.7"
   spec.add_dependency "grape-swagger", "~> 0.27"
   spec.add_dependency "jsonapi-resources", "~> 0.9.0"
-  spec.add_dependency "grape-jsonapi-resources", "~> 0.0.7"
+  spec.add_dependency "rails", ">= 4.2" # jsonapi-resources needs this but doesn't declare it
 
   spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "byebug"
+  spec.add_development_dependency "kaminari"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop"
-  spec.add_development_dependency "kaminari"
-  spec.add_development_dependency "byebug"
 end

--- a/grape-swagger-jsonapi-resources.gemspec
+++ b/grape-swagger-jsonapi-resources.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "kaminari"
+  spec.add_development_dependency "byebug"
 end

--- a/lib/grape/formatter/json_api_pagination.rb
+++ b/lib/grape/formatter/json_api_pagination.rb
@@ -131,7 +131,7 @@ module Grape
       end
 
       def jsonapi_options
-        @json_api_options ||= build_options_from_endpoint(endpoint)
+        @json_api_options ||= build_options_from_endpoint
                               .merge!(env['jsonapi_options'] || {})
       end
 
@@ -157,10 +157,10 @@ module Grape
         end.join('&')
       end
 
-      def build_options_from_endpoint(endpoint)
+      def build_options_from_endpoint
         options = {}
-        if endpoint.namespace_inheritable(:jsonapi_base_url)
-          options[:base_url] = endpoint.namespace_inheritable(:jsonapi_base_url)
+        if env['HTTP_ORIGIN']
+          options[:base_url] = env['HTTP_ORIGIN']
         end
         options
       end

--- a/lib/grape/formatter/json_api_pagination.rb
+++ b/lib/grape/formatter/json_api_pagination.rb
@@ -17,11 +17,9 @@ module Grape
       def serialize_resource(resource, env)
         @env = env
         @resource = resource
-        @endpoint = env['api.endpoint']
+        @endpoint = env["api.endpoint"]
 
-        if resource_class.nil?
-          return blank_resource_response(jsonapi_options, resource)
-        end
+        return blank_resource_response(jsonapi_options, resource) if resource_class.nil?
 
         build_main_json_output_data
         add_pagination_links if resource_supports_pagination?
@@ -34,8 +32,8 @@ module Grape
       # Ensure sort order is maintained, serialize_to_hash can reorder objects if
       # objects of the array are of different types (polymorphic cases)
       def build_main_json_output_data
-        if sorted_primary_ids && (data = json_output['data']).present?
-          json_output['data'] = data.sort_by { |d| sorted_primary_ids.index(d['id']) }
+        if sorted_primary_ids && (data = json_output["data"]).present?
+          json_output["data"] = data.sort_by { |d| sorted_primary_ids.index(d["id"]) }
         end
       end
 
@@ -44,14 +42,14 @@ module Grape
       end
 
       def add_pagination_links
-        json_output['links'] ||= {}
+        json_output["links"] ||= {}
 
-        add_link_to_json_output('self', original_uri)
+        add_link_to_json_output("self", original_uri)
 
         last_page_uri = build_query_for_different_page(resource.total_pages)
-        add_link_to_json_output('last', last_page_uri)
+        add_link_to_json_output("last", last_page_uri)
         first_page_uri = build_query_for_different_page(1)
-        add_link_to_json_output('first', first_page_uri)
+        add_link_to_json_output("first", first_page_uri)
 
         add_previous_page_link if current_page_is_not_the_first_page
         add_next_page_link if current_page_is_not_the_last_page
@@ -60,13 +58,13 @@ module Grape
       def add_next_page_link
         next_or_last_page_number = [resource.total_pages, resource.current_page.succ].min
         next_page_uri = build_query_for_different_page(next_or_last_page_number)
-        add_link_to_json_output('next', next_page_uri)
+        add_link_to_json_output("next", next_page_uri)
       end
 
       def add_previous_page_link
         first_or_previous_page_number = [1, resource.current_page.pred].max
         prev_page_uri = build_query_for_different_page(first_or_previous_page_number)
-        add_link_to_json_output('prev', prev_page_uri)
+        add_link_to_json_output("prev", prev_page_uri)
       end
 
       def build_query_for_different_page(query)
@@ -82,7 +80,7 @@ module Grape
       end
 
       def add_link_to_json_output(link_name, uri)
-        json_output['links'][link_name] = uri.to_s
+        json_output["links"][link_name] = uri.to_s
       end
 
       def resource_class
@@ -126,13 +124,13 @@ module Grape
 
       def resource_serialized
         @resource_serialized ||= JSONAPI::ResourceSerializer
-                                 .new(resource_class, jsonapi_options)
-                                 .serialize_to_hash(resource_instances)
+          .new(resource_class, jsonapi_options)
+          .serialize_to_hash(resource_instances)
       end
 
       def jsonapi_options
         @json_api_options ||= build_options_from_endpoint
-                              .merge!(env['jsonapi_options'] || {})
+          .merge!(env["jsonapi_options"] || {})
       end
 
       def original_uri
@@ -144,7 +142,7 @@ module Grape
       end
 
       def uri_with_page_number(page_number)
-        original_query.merge('page[number]' => page_number)
+        original_query.merge("page[number]" => page_number)
       end
 
       def build_query(params)
@@ -154,14 +152,12 @@ module Grape
           else
             v.nil? ? k : "#{k}=#{v}"
           end
-        end.join('&')
+        end.join("&")
       end
 
       def build_options_from_endpoint
         options = {}
-        if env['HTTP_ORIGIN']
-          options[:base_url] = env['HTTP_ORIGIN']
-        end
+        options[:base_url] = env["HTTP_ORIGIN"] if env["HTTP_ORIGIN"]
         options
       end
 
@@ -193,7 +189,7 @@ module Grape
       end
 
       def blank_resource_response(jsonapi_options, resource)
-        return nil unless resource.blank?
+        return nil if resource.present?
 
         blank_return = {}
         blank_return[:data] = resource.respond_to?(:to_ary) ? [] : {}

--- a/lib/grape/formatter/json_api_pagination.rb
+++ b/lib/grape/formatter/json_api_pagination.rb
@@ -1,5 +1,10 @@
+# frozen_string_literal: true
+
 module Grape
   module Formatter
+    # This an extended and refactored version of the JSONAPI resources formatter
+    # that adds pagination links if there is a wrapper e.g. Kaminari that provides
+    # the appropriate pagination methods.
     class JsonApiPagination
       class << self
         def call(resource, env)
@@ -7,91 +12,135 @@ module Grape
         end
       end
 
-      attr_reader :env, :resource
+      attr_reader :env, :resource, :endpoint
 
       def serialize_resource(resource, env)
         @env = env
         @resource = resource
-
-        endpoint = env['api.endpoint']
-
-        jsonapi_options = build_options_from_endpoint(endpoint)
-        jsonapi_options.merge!(env['jsonapi_options'] || {})
-
-        context = {}
-        context[:current_user] = endpoint.current_user if endpoint.respond_to?(:current_user)
-        context.merge!(jsonapi_options.delete(:context)) if jsonapi_options[:context]
-
-        resource_class = resource_class_for(resource)
+        @endpoint = env['api.endpoint']
 
         if resource_class.nil?
           return blank_resource_response(jsonapi_options, resource)
         end
 
-        sorted_primary_ids = nil
-        if resource.respond_to?(:to_ary)
-          resource_instances = resource.to_ary.compact.collect do |each_resource|
-            each_resource_class = resource_class_for(each_resource)
-            each_resource_class.new(each_resource, context)
-          end
-          sorted_primary_ids = resource_instances.collect { |resource_instance| resource_instance.try(:id) }
-        else
-          resource_instances = resource_class.new(resource, context)
-        end
-
-        resource_serialized = JSONAPI::ResourceSerializer
-                                .new(resource_class, jsonapi_options)
-                                .serialize_to_hash(resource_instances)
-        json_output = if jsonapi_options[:meta]
-                        # Add option to merge top level meta tag as
-                        # jsonapi-resources does not appear to support this
-                        resource_serialized.as_json.merge(meta: jsonapi_options[:meta])
-                      else
-                        resource_serialized
-                      end
-
-        # Ensure sort order is maintained, serialize_to_hash can reorder objects if
-        # objects of the array are of different types (polymorphic cases)
-        json_output = json_output.stringify_keys
-        if sorted_primary_ids && (data = json_output["data"]).present?
-          sorted_primary_ids = sorted_primary_ids.map(&:to_s)
-          json_output["data"] = data.sort_by { |d| sorted_primary_ids.index(d["id"]) }
-        end
-
-        if resource.respond_to?(:current_page) && resource.respond_to?(:total_pages)
-          json_output["links"] ||= {}
-
-          original_uri = URI("#{jsonapi_options[:base_url]}#{env['REQUEST_URI']}")
-          json_output["links"]["self"] = original_uri.to_s
-
-          original_query = Rack::Utils.parse_query(original_uri.query)
-
-          last_page_query = original_query.merge('page[number]' => resource.total_pages)
-          last_page_uri = original_uri.dup.tap { |uri| uri.query = build_query(last_page_query) }
-          json_output["links"]["last"] = last_page_uri.to_s
-
-          first_page_query = original_query.merge('page[number]' => 1)
-          first_page_uri = original_uri.dup.tap { |uri| uri.query = build_query(first_page_query) }
-          json_output["links"]["first"] = first_page_uri.to_s
-
-          if resource.current_page > 1
-            prev_page_query = original_query.merge('page[number]' => [1, resource.current_page.pred].max)
-            prev_page_uri = original_uri.dup.tap { |uri| uri.query = build_query(prev_page_query) }
-            json_output["links"]["prev"] = prev_page_uri.to_s
-          end
-
-          if resource.current_page < resource.total_pages && resource.total_pages > 1
-            next_page_query = original_query.merge('page[number]' => [resource.total_pages, resource.current_page.succ].min)
-            next_page_uri = original_uri.dup.tap { |uri| uri.query = build_query(next_page_query) }
-            json_output["links"]["next"] = next_page_uri.to_s
-          end
-        end
+        build_main_json_output_data
+        add_pagination_links if resource_supports_pagination?
 
         json_output.to_json
       end
 
-      def original_uri(jsonapi_options)
+      private
+
+      # Ensure sort order is maintained, serialize_to_hash can reorder objects if
+      # objects of the array are of different types (polymorphic cases)
+      def build_main_json_output_data
+        if sorted_primary_ids && (data = json_output['data']).present?
+          json_output['data'] = data.sort_by { |d| sorted_primary_ids.index(d['id']) }
+        end
+      end
+
+      def resource_supports_pagination?
+        resource.respond_to?(:current_page) && resource.respond_to?(:total_pages)
+      end
+
+      def add_pagination_links
+        json_output['links'] ||= {}
+
+        add_link_to_json_output('self', original_uri)
+
+        last_page_uri = build_query_for_different_page(resource.total_pages)
+        add_link_to_json_output('last', last_page_uri)
+        first_page_uri = build_query_for_different_page(1)
+        add_link_to_json_output('first', first_page_uri)
+
+        add_previous_page_link if current_page_is_not_the_first_page
+        add_next_page_link if current_page_is_not_the_last_page
+      end
+
+      def add_next_page_link
+        next_or_last_page_number = [resource.total_pages, resource.current_page.succ].min
+        next_page_uri = build_query_for_different_page(next_or_last_page_number)
+        add_link_to_json_output('next', next_page_uri)
+      end
+
+      def add_previous_page_link
+        first_or_previous_page_number = [1, resource.current_page.pred].max
+        prev_page_uri = build_query_for_different_page(first_or_previous_page_number)
+        add_link_to_json_output('prev', prev_page_uri)
+      end
+
+      def build_query_for_different_page(query)
+        original_uri.dup.tap { |uri| uri.query = build_query(uri_with_page_number(query)) }
+      end
+
+      def current_page_is_not_the_first_page
+        resource.current_page > 1
+      end
+
+      def current_page_is_not_the_last_page
+        resource.current_page < resource.total_pages
+      end
+
+      def add_link_to_json_output(link_name, uri)
+        json_output['links'][link_name] = uri.to_s
+      end
+
+      def resource_class
+        resource_class_for(resource)
+      end
+
+      def context
+        return @context if @context
+        @context = {}
+        @context[:current_user] = endpoint.current_user if endpoint.respond_to?(:current_user)
+        @context.merge!(jsonapi_options.delete(:context)) if jsonapi_options[:context]
+      end
+
+      def resource_instances
+        @resource_instances ||= if resource.respond_to?(:to_ary)
+                                  resource.to_ary.compact.collect do |each_resource|
+                                    each_resource_class = resource_class_for(each_resource)
+                                    each_resource_class.new(each_resource, context)
+                                  end
+                                else
+                                  resource_class.new(resource, context)
+                                end
+      end
+
+      def sorted_primary_ids
+        return @sorted_primary_ids if @sorted_primary_ids
+        if resource.respond_to?(:to_ary)
+          @sorted_primary_ids = resource_instances.collect { |resource_instance| resource_instance.try(:id) }
+        end
+      end
+
+      def json_output
+        @json_output ||= if jsonapi_options[:meta]
+                           # Add option to merge top level meta tag as
+                           # jsonapi-resources does not appear to support this
+                           resource_serialized.as_json.merge(meta: jsonapi_options[:meta])
+                         else
+                           resource_serialized
+                         end.stringify_keys
+      end
+
+      def resource_serialized
+        @resource_serialized ||= JSONAPI::ResourceSerializer
+                                 .new(resource_class, jsonapi_options)
+                                 .serialize_to_hash(resource_instances)
+      end
+
+      def jsonapi_options
+        @json_api_options ||= build_options_from_endpoint(endpoint)
+                              .merge!(env['jsonapi_options'] || {})
+      end
+
+      def original_uri
         URI("#{jsonapi_options[:base_url]}#{env['REQUEST_URI']}")
+      end
+
+      def original_query
+        Rack::Utils.parse_query(original_uri.query)
       end
 
       def uri_with_page_number(page_number)
@@ -99,13 +148,13 @@ module Grape
       end
 
       def build_query(params)
-        params.map { |k, v|
+        params.map do |k, v|
           if v.class == Array
             build_query(v.map { |x| [k, x] })
           else
             v.nil? ? k : "#{k}=#{v}"
           end
-        }.join("&")
+        end.join('&')
       end
 
       def build_options_from_endpoint(endpoint)
@@ -142,8 +191,6 @@ module Grape
           end
         end
       end
-
-      private
 
       def blank_resource_response(jsonapi_options, resource)
         return nil unless resource.blank?

--- a/lib/grape/formatter/json_api_pagination.rb
+++ b/lib/grape/formatter/json_api_pagination.rb
@@ -1,0 +1,104 @@
+module Grape
+  module Formatter
+    module JsonApiPagination
+      class << self
+        def call(resource, env)
+          serialize_resource(resource, env) || Grape::Formatter::Json.call(resource, env)
+        end
+
+        def serialize_resource(resource, env)
+          endpoint = env['api.endpoint']
+          # byebug
+
+          jsonapi_options = build_options_from_endpoint(endpoint)
+          jsonapi_options.merge!(env['jsonapi_options'] || {})
+
+          context = {}
+          context.merge!(current_user: endpoint.current_user) if endpoint.respond_to?(:current_user)
+          context.merge!(jsonapi_options.delete(:context)) if jsonapi_options[:context]
+
+          resource_class = resource_class_for(resource)
+
+          if resource_class.nil?
+            if resource.blank?
+              # Return blank object
+              blank_return = {}
+              if resource.respond_to?(:to_ary)
+                blank_return[:data] = []
+              else
+                blank_return[:data] = {}
+              end
+              blank_return[:meta] = jsonapi_options[:meta] if jsonapi_options[:meta]
+              return blank_return.to_json
+            else
+              return nil
+            end
+          end
+
+          resource_instances = nil
+          sorted_primary_ids = nil
+          if resource.respond_to?(:to_ary)
+            resource_instances = resource.to_ary.compact.collect do |each_resource|
+              each_resource_class = resource_class_for(each_resource)
+              each_resource_class.new(each_resource, context)
+            end
+            sorted_primary_ids = resource_instances.collect { |resource_instance| resource_instance.try(:id) }
+          else
+            resource_instances = resource_class.new(resource, context)
+          end
+
+          resource_serialized = JSONAPI::ResourceSerializer.new(resource_class, jsonapi_options).serialize_to_hash(resource_instances)
+          json_output = if jsonapi_options[:meta]
+            # Add option to merge top level meta tag as jsonapi-resources does not appear to support this
+            resource_serialized.as_json.merge(meta: jsonapi_options[:meta])
+          else
+            resource_serialized
+          end
+
+          # Ensure sort order is maintained, serialize_to_hash can reorder objects if
+          # objects of the array are of different types (polymorphic cases)
+          json_output = json_output.stringify_keys
+          if sorted_primary_ids && (data = json_output["data"]).present?
+            sorted_primary_ids = sorted_primary_ids.map(&:to_s)
+            json_output["data"] = data.sort_by { |d| sorted_primary_ids.index(d["id"]) }
+          end
+
+          json_output.to_json
+        end
+
+        def build_options_from_endpoint(endpoint)
+          options = {}
+          options[:base_url] = endpoint.namespace_inheritable(:jsonapi_base_url) if endpoint.namespace_inheritable(:jsonapi_base_url)
+          options
+        end
+
+        def resource_class_for(resource)
+          if resource.class.respond_to?(:jsonapi_resource_class)
+            resource.class.jsonapi_resource_class
+          elsif resource.respond_to?(:to_ary)
+            resource_class_for(resource.to_ary.first)
+          else
+            get_resource_for(resource.class)
+          end
+        end
+
+        def resources_cache
+          @resources_cache ||= ThreadSafe::Cache.new
+        end
+
+        def get_resource_for(klass)
+          resources_cache.fetch_or_store(klass) do
+            resource_class_name = "#{klass.name}Resource"
+            resource_class = resource_class_name.safe_constantize
+
+            if resource_class
+              resource_class
+            elsif klass.superclass
+              get_resource_for(klass.superclass)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/grape/formatter/json_api_pagination.rb
+++ b/lib/grape/formatter/json_api_pagination.rb
@@ -55,11 +55,19 @@ module Grape
           if resource.respond_to?(:page)
             json_output["links"] ||= {}
 
-            json_output["links"]["self"] = "#{jsonapi_options[:base_url]}#{env['REQUEST_URI']}"
+            original_uri = URI("#{jsonapi_options[:base_url]}#{env['REQUEST_URI']}")
+            json_output["links"]["self"] = original_uri.to_s
 
-            # TODO get the base url
+            original_query = Rack::Utils.parse_query(original_uri.query)
 
-            # TODO pagination here
+            last_page_query = original_query.merge(number: resource.total_pages)
+            last_page_uri = original_uri.dup.tap { |uri| uri.query = Rack::Utils.build_query(last_page_query).to_s }
+            json_output["links"]["last"] = last_page_uri.to_s
+
+            first_page_query = original_query.merge(number: resource.total_pages)
+            first_page_uri = original_uri.dup.tap { |uri| uri.query = Rack::Utils.build_query(first_page_query) }
+            json_output["links"]["last"] = first_page_uri.to_s
+
           end
 
           json_output.to_json

--- a/lib/grape/formatter/json_api_pagination.rb
+++ b/lib/grape/formatter/json_api_pagination.rb
@@ -8,34 +8,20 @@ module Grape
 
         def serialize_resource(resource, env)
           endpoint = env['api.endpoint']
-          # byebug
 
           jsonapi_options = build_options_from_endpoint(endpoint)
           jsonapi_options.merge!(env['jsonapi_options'] || {})
 
           context = {}
-          context.merge!(current_user: endpoint.current_user) if endpoint.respond_to?(:current_user)
+          context[:current_user] = endpoint.current_user if endpoint.respond_to?(:current_user)
           context.merge!(jsonapi_options.delete(:context)) if jsonapi_options[:context]
 
           resource_class = resource_class_for(resource)
 
           if resource_class.nil?
-            if resource.blank?
-              # Return blank object
-              blank_return = {}
-              if resource.respond_to?(:to_ary)
-                blank_return[:data] = []
-              else
-                blank_return[:data] = {}
-              end
-              blank_return[:meta] = jsonapi_options[:meta] if jsonapi_options[:meta]
-              return blank_return.to_json
-            else
-              return nil
-            end
+            return blank_resource_response(jsonapi_options, resource)
           end
 
-          resource_instances = nil
           sorted_primary_ids = nil
           if resource.respond_to?(:to_ary)
             resource_instances = resource.to_ary.compact.collect do |each_resource|
@@ -47,13 +33,16 @@ module Grape
             resource_instances = resource_class.new(resource, context)
           end
 
-          resource_serialized = JSONAPI::ResourceSerializer.new(resource_class, jsonapi_options).serialize_to_hash(resource_instances)
+          resource_serialized = JSONAPI::ResourceSerializer
+                                .new(resource_class, jsonapi_options)
+                                .serialize_to_hash(resource_instances)
           json_output = if jsonapi_options[:meta]
-            # Add option to merge top level meta tag as jsonapi-resources does not appear to support this
-            resource_serialized.as_json.merge(meta: jsonapi_options[:meta])
-          else
-            resource_serialized
-          end
+                          # Add option to merge top level meta tag as
+                          # jsonapi-resources does not appear to support this
+                          resource_serialized.as_json.merge(meta: jsonapi_options[:meta])
+                        else
+                          resource_serialized
+                        end
 
           # Ensure sort order is maintained, serialize_to_hash can reorder objects if
           # objects of the array are of different types (polymorphic cases)
@@ -63,18 +52,24 @@ module Grape
             json_output["data"] = data.sort_by { |d| sorted_primary_ids.index(d["id"]) }
           end
 
-          # TODO add links object
+          if resource.respond_to?(:page)
+            json_output["links"] ||= {}
 
-          # TODO get the base url
+            json_output["links"]["self"] = "#{jsonapi_options[:base_url]}#{env['REQUEST_URI']}"
 
-          # TODO pagination here
+            # TODO get the base url
+
+            # TODO pagination here
+          end
 
           json_output.to_json
         end
 
         def build_options_from_endpoint(endpoint)
           options = {}
-          options[:base_url] = endpoint.namespace_inheritable(:jsonapi_base_url) if endpoint.namespace_inheritable(:jsonapi_base_url)
+          if endpoint.namespace_inheritable(:jsonapi_base_url)
+            options[:base_url] = endpoint.namespace_inheritable(:jsonapi_base_url)
+          end
           options
         end
 
@@ -103,6 +98,17 @@ module Grape
               get_resource_for(klass.superclass)
             end
           end
+        end
+
+        private
+
+        def blank_resource_response(jsonapi_options, resource)
+          return nil unless resource.blank?
+
+          blank_return = {}
+          blank_return[:data] = resource.respond_to?(:to_ary) ? [] : {}
+          blank_return[:meta] = jsonapi_options[:meta] if jsonapi_options[:meta]
+          blank_return.to_json
         end
       end
     end

--- a/lib/grape/formatter/json_api_pagination.rb
+++ b/lib/grape/formatter/json_api_pagination.rb
@@ -63,6 +63,12 @@ module Grape
             json_output["data"] = data.sort_by { |d| sorted_primary_ids.index(d["id"]) }
           end
 
+          # TODO add links object
+
+          # TODO get the base url
+
+          # TODO pagination here
+
           json_output.to_json
         end
 

--- a/lib/grape/formatter/json_api_pagination.rb
+++ b/lib/grape/formatter/json_api_pagination.rb
@@ -1,140 +1,157 @@
 module Grape
   module Formatter
-    module JsonApiPagination
+    class JsonApiPagination
       class << self
         def call(resource, env)
-          serialize_resource(resource, env) || Grape::Formatter::Json.call(resource, env)
+          new.serialize_resource(resource, env) || Grape::Formatter::Json.call(resource, env)
+        end
+      end
+
+      attr_reader :env, :resource
+
+      def serialize_resource(resource, env)
+        @env = env
+        @resource = resource
+
+        endpoint = env['api.endpoint']
+
+        jsonapi_options = build_options_from_endpoint(endpoint)
+        jsonapi_options.merge!(env['jsonapi_options'] || {})
+
+        context = {}
+        context[:current_user] = endpoint.current_user if endpoint.respond_to?(:current_user)
+        context.merge!(jsonapi_options.delete(:context)) if jsonapi_options[:context]
+
+        resource_class = resource_class_for(resource)
+
+        if resource_class.nil?
+          return blank_resource_response(jsonapi_options, resource)
         end
 
-        def serialize_resource(resource, env)
-          endpoint = env['api.endpoint']
-
-          jsonapi_options = build_options_from_endpoint(endpoint)
-          jsonapi_options.merge!(env['jsonapi_options'] || {})
-
-          context = {}
-          context[:current_user] = endpoint.current_user if endpoint.respond_to?(:current_user)
-          context.merge!(jsonapi_options.delete(:context)) if jsonapi_options[:context]
-
-          resource_class = resource_class_for(resource)
-
-          if resource_class.nil?
-            return blank_resource_response(jsonapi_options, resource)
+        sorted_primary_ids = nil
+        if resource.respond_to?(:to_ary)
+          resource_instances = resource.to_ary.compact.collect do |each_resource|
+            each_resource_class = resource_class_for(each_resource)
+            each_resource_class.new(each_resource, context)
           end
+          sorted_primary_ids = resource_instances.collect { |resource_instance| resource_instance.try(:id) }
+        else
+          resource_instances = resource_class.new(resource, context)
+        end
 
-          sorted_primary_ids = nil
-          if resource.respond_to?(:to_ary)
-            resource_instances = resource.to_ary.compact.collect do |each_resource|
-              each_resource_class = resource_class_for(each_resource)
-              each_resource_class.new(each_resource, context)
-            end
-            sorted_primary_ids = resource_instances.collect { |resource_instance| resource_instance.try(:id) }
-          else
-            resource_instances = resource_class.new(resource, context)
-          end
-
-          resource_serialized = JSONAPI::ResourceSerializer
+        resource_serialized = JSONAPI::ResourceSerializer
                                 .new(resource_class, jsonapi_options)
                                 .serialize_to_hash(resource_instances)
-          json_output = if jsonapi_options[:meta]
-                          # Add option to merge top level meta tag as
-                          # jsonapi-resources does not appear to support this
-                          resource_serialized.as_json.merge(meta: jsonapi_options[:meta])
-                        else
-                          resource_serialized
-                        end
+        json_output = if jsonapi_options[:meta]
+                        # Add option to merge top level meta tag as
+                        # jsonapi-resources does not appear to support this
+                        resource_serialized.as_json.merge(meta: jsonapi_options[:meta])
+                      else
+                        resource_serialized
+                      end
 
-          # Ensure sort order is maintained, serialize_to_hash can reorder objects if
-          # objects of the array are of different types (polymorphic cases)
-          json_output = json_output.stringify_keys
-          if sorted_primary_ids && (data = json_output["data"]).present?
-            sorted_primary_ids = sorted_primary_ids.map(&:to_s)
-            json_output["data"] = data.sort_by { |d| sorted_primary_ids.index(d["id"]) }
-          end
+        # Ensure sort order is maintained, serialize_to_hash can reorder objects if
+        # objects of the array are of different types (polymorphic cases)
+        json_output = json_output.stringify_keys
+        if sorted_primary_ids && (data = json_output["data"]).present?
+          sorted_primary_ids = sorted_primary_ids.map(&:to_s)
+          json_output["data"] = data.sort_by { |d| sorted_primary_ids.index(d["id"]) }
+        end
 
-          if resource.respond_to?(:page)
-            json_output["links"] ||= {}
+        if resource.respond_to?(:current_page) && resource.respond_to?(:total_pages)
+          json_output["links"] ||= {}
 
-            original_uri = URI("#{jsonapi_options[:base_url]}#{env['REQUEST_URI']}")
-            json_output["links"]["self"] = original_uri.to_s
+          original_uri = URI("#{jsonapi_options[:base_url]}#{env['REQUEST_URI']}")
+          json_output["links"]["self"] = original_uri.to_s
 
-            original_query = Rack::Utils.parse_query(original_uri.query)
+          original_query = Rack::Utils.parse_query(original_uri.query)
 
-            last_page_query = original_query.merge('page[number]' => resource.total_pages)
-            last_page_uri = original_uri.dup.tap { |uri| uri.query = build_query(last_page_query) }
-            json_output["links"]["last"] = last_page_uri.to_s
+          last_page_query = original_query.merge('page[number]' => resource.total_pages)
+          last_page_uri = original_uri.dup.tap { |uri| uri.query = build_query(last_page_query) }
+          json_output["links"]["last"] = last_page_uri.to_s
 
-            first_page_query = original_query.merge('page[number]' => 1)
-            first_page_uri = original_uri.dup.tap { |uri| uri.query = build_query(first_page_query) }
-            json_output["links"]["first"] = first_page_uri.to_s
+          first_page_query = original_query.merge('page[number]' => 1)
+          first_page_uri = original_uri.dup.tap { |uri| uri.query = build_query(first_page_query) }
+          json_output["links"]["first"] = first_page_uri.to_s
 
-            prev_page_query = original_query.merge('page[number]' => [1, resource.current_page.pred].max )
+          if resource.current_page > 1
+            prev_page_query = original_query.merge('page[number]' => [1, resource.current_page.pred].max)
             prev_page_uri = original_uri.dup.tap { |uri| uri.query = build_query(prev_page_query) }
             json_output["links"]["prev"] = prev_page_uri.to_s
+          end
 
+          if resource.current_page < resource.total_pages && resource.total_pages > 1
             next_page_query = original_query.merge('page[number]' => [resource.total_pages, resource.current_page.succ].min)
             next_page_uri = original_uri.dup.tap { |uri| uri.query = build_query(next_page_query) }
             json_output["links"]["next"] = next_page_uri.to_s
           end
-
-          json_output.to_json
         end
 
-        def build_query(params)
-          params.map { |k, v|
-            if v.class == Array
-              build_query(v.map { |x| [k, x] })
-            else
-              v.nil? ? k : "#{k}=#{v}"
-            end
-          }.join("&")
-        end
+        json_output.to_json
+      end
 
-        def build_options_from_endpoint(endpoint)
-          options = {}
-          if endpoint.namespace_inheritable(:jsonapi_base_url)
-            options[:base_url] = endpoint.namespace_inheritable(:jsonapi_base_url)
-          end
-          options
-        end
+      def original_uri(jsonapi_options)
+        URI("#{jsonapi_options[:base_url]}#{env['REQUEST_URI']}")
+      end
 
-        def resource_class_for(resource)
-          if resource.class.respond_to?(:jsonapi_resource_class)
-            resource.class.jsonapi_resource_class
-          elsif resource.respond_to?(:to_ary)
-            resource_class_for(resource.to_ary.first)
+      def uri_with_page_number(page_number)
+        original_query.merge('page[number]' => page_number)
+      end
+
+      def build_query(params)
+        params.map { |k, v|
+          if v.class == Array
+            build_query(v.map { |x| [k, x] })
           else
-            get_resource_for(resource.class)
+            v.nil? ? k : "#{k}=#{v}"
+          end
+        }.join("&")
+      end
+
+      def build_options_from_endpoint(endpoint)
+        options = {}
+        if endpoint.namespace_inheritable(:jsonapi_base_url)
+          options[:base_url] = endpoint.namespace_inheritable(:jsonapi_base_url)
+        end
+        options
+      end
+
+      def resource_class_for(resource)
+        if resource.class.respond_to?(:jsonapi_resource_class)
+          resource.class.jsonapi_resource_class
+        elsif resource.respond_to?(:to_ary)
+          resource_class_for(resource.to_ary.first)
+        else
+          get_resource_for(resource.class)
+        end
+      end
+
+      def resources_cache
+        @resources_cache ||= ThreadSafe::Cache.new
+      end
+
+      def get_resource_for(klass)
+        resources_cache.fetch_or_store(klass) do
+          resource_class_name = "#{klass.name}Resource"
+          resource_class = resource_class_name.safe_constantize
+
+          if resource_class
+            resource_class
+          elsif klass.superclass
+            get_resource_for(klass.superclass)
           end
         end
+      end
 
-        def resources_cache
-          @resources_cache ||= ThreadSafe::Cache.new
-        end
+      private
 
-        def get_resource_for(klass)
-          resources_cache.fetch_or_store(klass) do
-            resource_class_name = "#{klass.name}Resource"
-            resource_class = resource_class_name.safe_constantize
+      def blank_resource_response(jsonapi_options, resource)
+        return nil unless resource.blank?
 
-            if resource_class
-              resource_class
-            elsif klass.superclass
-              get_resource_for(klass.superclass)
-            end
-          end
-        end
-
-        private
-
-        def blank_resource_response(jsonapi_options, resource)
-          return nil unless resource.blank?
-
-          blank_return = {}
-          blank_return[:data] = resource.respond_to?(:to_ary) ? [] : {}
-          blank_return[:meta] = jsonapi_options[:meta] if jsonapi_options[:meta]
-          blank_return.to_json
-        end
+        blank_return = {}
+        blank_return[:data] = resource.respond_to?(:to_ary) ? [] : {}
+        blank_return[:meta] = jsonapi_options[:meta] if jsonapi_options[:meta]
+        blank_return.to_json
       end
     end
   end

--- a/lib/grape/formatter/link.rb
+++ b/lib/grape/formatter/link.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Grape
+  module Formatter
+    class Link
+      attr_reader :uri, :merge_params
+
+      def initialize(uri, merge_params)
+        @uri = uri
+        @merge_params = merge_params
+      end
+
+      def to_s
+        uri.dup.tap { |uri| uri.query = build_query(original_query.merge(merge_params)) }
+      end
+
+      private
+
+      def build_query(params)
+        params.map do |k, v|
+          if v.class == Array
+            build_query(v.map { |x| [k, x] })
+          else
+            v.nil? ? k : "#{k}=#{v}"
+          end
+        end.join("&")
+      end
+
+      def original_query
+        Rack::Utils.parse_query(uri.query)
+      end
+    end
+  end
+end

--- a/lib/grape/swagger/jsonapi/resources.rb
+++ b/lib/grape/swagger/jsonapi/resources.rb
@@ -1,15 +1,17 @@
-require "grape-swagger"
+require 'grape-swagger'
 
 # Only require the bits of Rails that jsonapi-resources uses
-require "action_controller"
-require "rails"
+require 'action_controller'
+require 'rails'
+require 'byebug'
 
-require "jsonapi-resources"
+require 'jsonapi-resources'
 
-require "grape-jsonapi-resources"
-require "grape/swagger/jsonapi/resources/version"
-require "grape/swagger/jsonapi/resources/parser"
-require "grape/swagger/jsonapi/resources/endpoint_extensions"
-require "grape/swagger/jsonapi/resources/entity_name"
+require 'grape-jsonapi-resources'
+require 'grape/swagger/jsonapi/resources/version'
+require 'grape/swagger/jsonapi/resources/parser'
+require 'grape/swagger/jsonapi/resources/endpoint_extensions'
+require 'grape/swagger/jsonapi/resources/entity_name'
+require 'grape/formatter/json_api_pagination'
 
 GrapeSwagger.model_parsers.register(Grape::Swagger::Jsonapi::Resources::Parser, JSONAPI::Resource)

--- a/lib/grape/swagger/jsonapi/resources.rb
+++ b/lib/grape/swagger/jsonapi/resources.rb
@@ -1,17 +1,16 @@
-require 'grape-swagger'
+require "grape-swagger"
 
 # Only require the bits of Rails that jsonapi-resources uses
-require 'action_controller'
-require 'rails'
-require 'byebug'
+require "action_controller"
+require "rails"
 
-require 'jsonapi-resources'
+require "jsonapi-resources"
 
-require 'grape-jsonapi-resources'
-require 'grape/swagger/jsonapi/resources/version'
-require 'grape/swagger/jsonapi/resources/parser'
-require 'grape/swagger/jsonapi/resources/endpoint_extensions'
-require 'grape/swagger/jsonapi/resources/entity_name'
-require 'grape/formatter/json_api_pagination'
+require "grape-jsonapi-resources"
+require "grape/swagger/jsonapi/resources/version"
+require "grape/swagger/jsonapi/resources/parser"
+require "grape/swagger/jsonapi/resources/endpoint_extensions"
+require "grape/swagger/jsonapi/resources/entity_name"
+require "grape/formatter/json_api_pagination"
 
 GrapeSwagger.model_parsers.register(Grape::Swagger::Jsonapi::Resources::Parser, JSONAPI::Resource)

--- a/lib/grape/swagger/jsonapi/resources/endpoint_extensions.rb
+++ b/lib/grape/swagger/jsonapi/resources/endpoint_extensions.rb
@@ -24,23 +24,23 @@ module Grape
       codes.map! { |x| x.is_a?(Array) ? { code: x[0], message: x[1], model: x[2] } : x }
 
       codes.each_with_object({}) do |this_http_code, all_responses|
-        this_http_code[:message] ||= ''
+        this_http_code[:message] ||= ""
         all_responses[this_http_code[:code]] = { description: this_http_code[:message] }
         next build_file_response(all_responses[this_http_code[:code]]) if file_response?(this_http_code[:model])
 
         response_model = @item
         response_model = expose_params_from_model(this_http_code[:model]) if this_http_code[:model]
 
-        if all_responses.key?(200) && route.request_method == 'DELETE' && this_http_code[:model].nil?
+        if all_responses.key?(200) && route.request_method == "DELETE" && this_http_code[:model].nil?
           all_responses[204] = all_responses.delete(200)
           this_http_code[:code] = 204
         end
 
         next if all_responses.key?(204)
-        next unless !response_model.start_with?('Swagger_doc') && (@definitions[response_model] || this_http_code[:model])
+        next unless !response_model.start_with?("Swagger_doc") && (@definitions[response_model] || this_http_code[:model])
 
         reference = {
-          '$ref' => "#/definitions/#{response_model}"
+          "$ref" => "#/definitions/#{response_model}"
         }
 
         json_api_response = {
@@ -53,7 +53,7 @@ module Grape
         json_api_response[:properties][:included] = included_models(this_http_code[:model]) if @entity._relationships.any?
 
         all_responses[this_http_code[:code]][:schema] = if route.options[:is_array] && this_http_code[:code] < 300
-                                                          { type: 'array', items: reference }
+                                                          { type: "array", items: reference }
                                                         else
                                                           json_api_response
                                                         end
@@ -68,7 +68,7 @@ module Grape
       models = Grape::Swagger::Jsonapi::Resources::Parser.new(model, self).included
       refs = models.map do |m|
         {
-          '$ref' => "#/definitions/#{expose_params_from_model(m)}"
+          "$ref" => "#/definitions/#{expose_params_from_model(m)}"
         }
       end
       {

--- a/lib/grape/swagger/jsonapi/resources/endpoint_extensions.rb
+++ b/lib/grape/swagger/jsonapi/resources/endpoint_extensions.rb
@@ -3,7 +3,7 @@
 module Grape
   # This is for inclusion into Grape::Endpoint after the stuff from grape-swagger
   class Endpoint
-    alias_method :original_response_object, :response_object
+    alias original_response_object response_object
 
     def response_object(route)
       if endpoint_uses_jsonapi?
@@ -60,7 +60,8 @@ module Grape
       end
     end
 
-    # This uses anyOf, but swagger UI seems not to display it properly and you just get an empty object with null in it.
+    # This uses anyOf, but swagger UI seems not to display it properly and you
+    # just get an empty object with null in it.
     # https://github.com/swagger-api/swagger-ui/issues/3859
     # https://github.com/swagger-api/swagger-ui/pull/4136
     def included_models(model)

--- a/lib/grape/swagger/jsonapi/resources/entity_name.rb
+++ b/lib/grape/swagger/jsonapi/resources/entity_name.rb
@@ -5,14 +5,14 @@ module GrapeSwagger
       def self.parse_entity_name(model)
         if model.methods(false).include?(:entity_name)
           model.entity_name
-        elsif model.to_s.end_with?('::Entity', '::Entities')
-          model.to_s.split('::')[-2]
-        elsif model.to_s.end_with?('Resource')
-          model.to_s.gsub('Resource', '')
+        elsif model.to_s.end_with?("::Entity", "::Entities")
+          model.to_s.split("::")[-2]
+        elsif model.to_s.end_with?("Resource")
+          model.to_s.gsub("Resource", "")
         elsif model.respond_to?(:name)
           model.name.demodulize.camelize
         else
-          model.to_s.split('::').last
+          model.to_s.split("::").last
         end
       end
     end

--- a/lib/grape/swagger/jsonapi/resources/parser.rb
+++ b/lib/grape/swagger/jsonapi/resources/parser.rb
@@ -102,4 +102,3 @@ module Grape
     end
   end
 end
-

--- a/lib/grape/swagger/jsonapi/resources/version.rb
+++ b/lib/grape/swagger/jsonapi/resources/version.rb
@@ -2,7 +2,7 @@ module Grape
   module Swagger
     module Jsonapi
       module Resources
-        VERSION = "0.1.0"
+        VERSION = "0.1.0".freeze
       end
     end
   end

--- a/spec/grape/formatter/json_api_pagination_spec.rb
+++ b/spec/grape/formatter/json_api_pagination_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-require 'kaminari'
+require "spec_helper"
+require "kaminari"
 
 Merchant = Struct.new(:id, :name)
 Product = Struct.new(:id, :name)
@@ -19,56 +19,56 @@ class MerchantResource < JSONAPI::Resource
 end
 
 RSpec.describe Grape::Formatter::JsonApiPagination do
-  let(:base_url) { 'http://localhost:3000' }
-  let(:fake_endpoint) { double('endpoint', namespace_inheritable: base_url) }
+  let(:base_url) { "http://localhost:3000" }
+  let(:fake_endpoint) { double("endpoint", namespace_inheritable: base_url) }
   let(:fake_env) do
     {
-      'api.endpoint' => fake_endpoint
+      "api.endpoint" => fake_endpoint
     }
   end
   let(:resource) do
     [
-      Merchant.new(12, 'Purton'),
-      Merchant.new(13, 'Anspach')
+      Merchant.new(12, "Purton"),
+      Merchant.new(13, "Anspach")
     ]
   end
 
-  describe 'characterisation spec for the JSONAPI response' do
-    it 'matches the spec' do
+  describe "characterisation spec for the JSONAPI response" do
+    it "matches the spec" do
       expected = {
-        'data' => [
+        "data" => [
           {
-            'id' => '12',
-            'type' => 'merchants',
-            'links' => {
-              'self' => 'http://localhost:3000/merchants/12'
+            "id" => "12",
+            "type" => "merchants",
+            "links" => {
+              "self" => "http://localhost:3000/merchants/12"
             },
-            'attributes' => {
-              'name' => 'Purton'
+            "attributes" => {
+              "name" => "Purton"
             },
-            'relationships' => {
-              'product' => {
-                'links' => {
-                  'self' => 'http://localhost:3000/merchants/12/relationships/product',
-                  'related' => 'http://localhost:3000/merchants/12/product'
+            "relationships" => {
+              "product" => {
+                "links" => {
+                  "self" => "http://localhost:3000/merchants/12/relationships/product",
+                  "related" => "http://localhost:3000/merchants/12/product"
                 }
               }
             }
           },
           {
-            'id' => '13',
-            'type' => 'merchants',
-            'links' => {
-              'self' => 'http://localhost:3000/merchants/13'
+            "id" => "13",
+            "type" => "merchants",
+            "links" => {
+              "self" => "http://localhost:3000/merchants/13"
             },
-            'attributes' => {
-              'name' => 'Anspach'
+            "attributes" => {
+              "name" => "Anspach"
             },
-            'relationships' => {
-              'product' => {
-                'links' => {
-                  'self' => 'http://localhost:3000/merchants/13/relationships/product',
-                  'related' => 'http://localhost:3000/merchants/13/product'
+            "relationships" => {
+              "product" => {
+                "links" => {
+                  "self" => "http://localhost:3000/merchants/13/relationships/product",
+                  "related" => "http://localhost:3000/merchants/13/product"
                 }
               }
             }
@@ -80,28 +80,28 @@ RSpec.describe Grape::Formatter::JsonApiPagination do
     end
   end
 
-  describe 'pagination' do
-    context 'when there is no pagination supplied' do
-      it 'provides no pagination links' do
-        resource = [Merchant.new(12, 'Purton')]
+  describe "pagination" do
+    context "when there is no pagination supplied" do
+      it "provides no pagination links" do
+        resource = [Merchant.new(12, "Purton")]
 
         actual = described_class.call(resource, fake_env)
         expected = {
           data: [
             {
-              id: '12',
-              type: 'merchants',
+              id: "12",
+              type: "merchants",
               links: {
-                self: 'http://localhost:3000/merchants/12'
+                self: "http://localhost:3000/merchants/12"
               },
               attributes: {
-                name: 'Purton'
+                name: "Purton"
               },
               relationships: {
                 product: {
                   links: {
-                    self: 'http://localhost:3000/merchants/12/relationships/product',
-                    related: 'http://localhost:3000/merchants/12/product'
+                    self: "http://localhost:3000/merchants/12/relationships/product",
+                    related: "http://localhost:3000/merchants/12/product"
                   }
                 }
               }
@@ -113,80 +113,80 @@ RSpec.describe Grape::Formatter::JsonApiPagination do
       end
     end
 
-    context 'with a paginated resource supplied' do
+    context "with a paginated resource supplied" do
       let(:pagination_links) do
-        JSON.parse(described_class.call(resource, fake_env))['links']
+        JSON.parse(described_class.call(resource, fake_env))["links"]
       end
 
-      context 'when there is only one page' do
+      context "when there is only one page" do
         let(:fake_env) do
           {
-            'api.endpoint' => fake_endpoint,
-            'REQUEST_URI' => '/merchants?page[number]=1&page[size]=2',
-            'PATH_INFO' => '/merchants',
-            'QUERY_STRING' => 'page[number]=1&page[size]=2'
+            "api.endpoint" => fake_endpoint,
+            "REQUEST_URI" => "/merchants?page[number]=1&page[size]=2",
+            "PATH_INFO" => "/merchants",
+            "QUERY_STRING" => "page[number]=1&page[size]=2"
           }
         end
         let(:resource) do
           Kaminari.paginate_array(
             [
-              Merchant.new(12, 'Purton')
+              Merchant.new(12, "Purton")
             ]
           ).page(1).per(2)
         end
 
-        it 'provides pagination links' do
+        it "provides pagination links" do
           expected = {
-            self: 'http://localhost:3000/merchants?page[number]=1&page[size]=2',
-            first: 'http://localhost:3000/merchants?page[number]=1&page[size]=2',
-            last: 'http://localhost:3000/merchants?page[number]=1&page[size]=2'
+            self: "http://localhost:3000/merchants?page[number]=1&page[size]=2",
+            first: "http://localhost:3000/merchants?page[number]=1&page[size]=2",
+            last: "http://localhost:3000/merchants?page[number]=1&page[size]=2"
           }
 
           expect(pagination_links).to eq expected.as_json
         end
       end
 
-      context 'when there are multiple pages' do
-        context 'when we are on the middle page' do
+      context "when there are multiple pages" do
+        context "when we are on the middle page" do
           let(:fake_env) do
             {
-              'api.endpoint' => fake_endpoint,
-              'REQUEST_URI' => '/merchants?page[number]=2&page[size]=2',
-              'PATH_INFO' => '/merchants',
-              'QUERY_STRING' => 'page[number]=2&page[size]=2'
+              "api.endpoint" => fake_endpoint,
+              "REQUEST_URI" => "/merchants?page[number]=2&page[size]=2",
+              "PATH_INFO" => "/merchants",
+              "QUERY_STRING" => "page[number]=2&page[size]=2"
             }
           end
           let(:resource) do
             Kaminari.paginate_array(
               [
-                Merchant.new(12, 'Purton'),
-                Merchant.new(13, 'Anspach'),
-                Merchant.new(14, 'Fourpure'),
-                Merchant.new(15, 'Naty'),
-                Merchant.new(16, 'Ranas'),
-                Merchant.new(17, 'Longmans'),
+                Merchant.new(12, "Purton"),
+                Merchant.new(13, "Anspach"),
+                Merchant.new(14, "Fourpure"),
+                Merchant.new(15, "Naty"),
+                Merchant.new(16, "Ranas"),
+                Merchant.new(17, "Longmans"),
               ]
             ).page(2).per(2)
           end
 
-          it 'provides a pagination link for the first page' do
-            expected_link = 'http://localhost:3000/merchants?page[number]=1&page[size]=2'
-            expect(pagination_links['first']).to eq expected_link
+          it "provides a pagination link for the first page" do
+            expected_link = "http://localhost:3000/merchants?page[number]=1&page[size]=2"
+            expect(pagination_links["first"]).to eq expected_link
           end
 
-          it 'provides a pagination link for the last page' do
-            expected_link = 'http://localhost:3000/merchants?page[number]=3&page[size]=2'
-            expect(pagination_links['last']).to eq expected_link
+          it "provides a pagination link for the last page" do
+            expected_link = "http://localhost:3000/merchants?page[number]=3&page[size]=2"
+            expect(pagination_links["last"]).to eq expected_link
           end
 
-          it 'provides a pagination link for the previous page' do
-            expected_link = 'http://localhost:3000/merchants?page[number]=1&page[size]=2'
-            expect(pagination_links['prev']).to eq expected_link
+          it "provides a pagination link for the previous page" do
+            expected_link = "http://localhost:3000/merchants?page[number]=1&page[size]=2"
+            expect(pagination_links["prev"]).to eq expected_link
           end
 
-          it 'provides a pagination link for the next page' do
-            expected_link = 'http://localhost:3000/merchants?page[number]=3&page[size]=2'
-            expect(pagination_links['next']).to eq expected_link
+          it "provides a pagination link for the next page" do
+            expected_link = "http://localhost:3000/merchants?page[number]=3&page[size]=2"
+            expect(pagination_links["next"]).to eq expected_link
           end
         end
       end

--- a/spec/grape/formatter/json_api_pagination_spec.rb
+++ b/spec/grape/formatter/json_api_pagination_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe Grape::Formatter::JsonApiPagination do
   let(:fake_endpoint) { double("endpoint", namespace_inheritable: base_url) }
   let(:fake_env) do
     {
-      "api.endpoint" => fake_endpoint
+      "api.endpoint" => fake_endpoint,
+      "HTTP_ORIGIN" => "http://localhost:3000",
     }
   end
   let(:resource) do
@@ -124,7 +125,8 @@ RSpec.describe Grape::Formatter::JsonApiPagination do
             "api.endpoint" => fake_endpoint,
             "REQUEST_URI" => "/merchants?page[number]=1&page[size]=2",
             "PATH_INFO" => "/merchants",
-            "QUERY_STRING" => "page[number]=1&page[size]=2"
+            "QUERY_STRING" => "page[number]=1&page[size]=2",
+            "HTTP_ORIGIN" => "http://localhost:3000",
           }
         end
         let(:resource) do
@@ -153,7 +155,8 @@ RSpec.describe Grape::Formatter::JsonApiPagination do
               "api.endpoint" => fake_endpoint,
               "REQUEST_URI" => "/merchants?page[number]=2&page[size]=2",
               "PATH_INFO" => "/merchants",
-              "QUERY_STRING" => "page[number]=2&page[size]=2"
+              "QUERY_STRING" => "page[number]=2&page[size]=2",
+              "HTTP_ORIGIN" => "http://localhost:3000",
             }
           end
           let(:resource) do

--- a/spec/grape/formatter/json_api_pagination_spec.rb
+++ b/spec/grape/formatter/json_api_pagination_spec.rb
@@ -41,7 +41,10 @@ RSpec.describe Grape::Formatter::JsonApiPagination do
                                          Merchant.new(12, 'Purton')
                                        ]).page(1).per(2)
     fake_env = {
-      'api.endpoint' => double('endpoint', namespace_inheritable: base_url)
+      'api.endpoint' => double('endpoint', namespace_inheritable: base_url),
+      'REQUEST_URI' => '/merchants?page[number]=1&page[size]=2',
+      'PATH_INFO' => '/merchants',
+      'QUERY_STRING' => 'page[number]=1&page[size]=2'
     }
     actual = described_class.call(resource, fake_env)
     expected = {
@@ -58,7 +61,7 @@ RSpec.describe Grape::Formatter::JsonApiPagination do
         }
       ],
       links: {
-        self: 'http://localhost:3000/merchants/12?page[number]=1&page[size]=2'
+        self: 'http://localhost:3000/merchants?page[number]=1&page[size]=2'
       }
     }
 

--- a/spec/grape/formatter/json_api_pagination_spec.rb
+++ b/spec/grape/formatter/json_api_pagination_spec.rb
@@ -1,17 +1,36 @@
 require 'spec_helper'
 
-# class StockOrderResource
+Merchant = Struct.new(:id, :name)
+
+class MerchantResource < JSONAPI::Resource
+  attribute :name
+end
 
 RSpec.describe Grape::Formatter::JsonApiPagination do
+  let(:base_url) { 'http://localhost:3000' }
+
   it 'provides pagination links' do
-    resource = double('active_record_resource', :to_ary => [])
-    fake_env = { 'api.endpoint' => double('endpoint', namespace_inheritable: '""') }
+    resource = [Merchant.new(12, 'Purton')]
+    fake_env = { 'api.endpoint' => double('endpoint', namespace_inheritable: base_url ) }
     actual = described_class.call(resource, fake_env)
     expected = {
-      data: {},
-      links: {}
+      data: [
+        {
+          id:'12',
+          type: 'merchants',
+          links: {
+            self: 'http://localhost:3000/merchants/12'
+          },
+          attributes: {
+            name: 'Purton'
+          },
+        }
+      ],
+      # links: {
+      #   self: "#{base_url}"
+      # }
     }
 
-    expect(actual).to eq expected
+    expect(JSON.parse(actual)).to eq expected.as_json
   end
 end

--- a/spec/grape/formatter/json_api_pagination_spec.rb
+++ b/spec/grape/formatter/json_api_pagination_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe Grape::Formatter::JsonApiPagination do
       end
 
       it 'provides pagination links' do
-        actual = described_class.call(resource, fake_env)
         expected = {
           self: 'http://localhost:3000/merchants?page[number]=1&page[size]=2',
           first: 'http://localhost:3000/merchants?page[number]=1&page[size]=2',
@@ -71,33 +70,45 @@ RSpec.describe Grape::Formatter::JsonApiPagination do
     end
 
     context 'when there are multiple pages' do
-      let(:fake_env) do
-        {
-          'api.endpoint' => double('endpoint', namespace_inheritable: base_url),
-          'REQUEST_URI' => '/merchants?page[number]=2&page[size]=2',
-          'PATH_INFO' => '/merchants',
-          'QUERY_STRING' => 'page[number]=2&page[size]=2'
-        }
-      end
-      let(:resource) do
-        Kaminari.paginate_array(
-          [
-            Merchant.new(12, 'Purton'),
-            Merchant.new(13, 'Anspach'),
-            Merchant.new(14, 'Fourpure'),
-            Merchant.new(15, 'Naty'),
-            Merchant.new(16, 'Ranas'),
-            Merchant.new(17, 'Longmans'),
-          ]
-        ).page(2).per(2)
-      end
+      context 'when we are on the middle page' do
+        let(:fake_env) do
+          {
+            'api.endpoint' => double('endpoint', namespace_inheritable: base_url),
+            'REQUEST_URI' => '/merchants?page[number]=2&page[size]=2',
+            'PATH_INFO' => '/merchants',
+            'QUERY_STRING' => 'page[number]=2&page[size]=2'
+          }
+        end
+        let(:resource) do
+          Kaminari.paginate_array(
+            [
+              Merchant.new(12, 'Purton'),
+              Merchant.new(13, 'Anspach'),
+              Merchant.new(14, 'Fourpure'),
+              Merchant.new(15, 'Naty'),
+              Merchant.new(16, 'Ranas'),
+              Merchant.new(17, 'Longmans'),
+            ]
+          ).page(2).per(2)
+        end
 
-      it 'provides a pagination link for the first page' do
-        expect(pagination_links["first"]).to eq 'http://localhost:3000/merchants?page[number]=1&page[size]=2'
-      end
+        it 'provides a pagination link for the first page' do
+          expect(pagination_links["first"]).to eq 'http://localhost:3000/merchants?page[number]=1&page[size]=2'
+        end
 
-      it 'provides a pagination link for the last page' do
-        expect(pagination_links["last"]).to eq 'http://localhost:3000/merchants?page[number]=3&page[size]=2'
+        it 'provides a pagination link for the last page' do
+          link = pagination_links["last"]
+          expect(link).to eq 'http://localhost:3000/merchants?page[number]=3&page[size]=2'
+        end
+
+        it 'provides a pagination link for the previous page' do
+          expect(pagination_links["prev"]).to eq 'http://localhost:3000/merchants?page[number]=1&page[size]=2'
+        end
+
+        it 'provides a pagination link for the next page' do
+          link = pagination_links["next"]
+          expect(link).to eq 'http://localhost:3000/merchants?page[number]=3&page[size]=2'
+        end
       end
     end
   end

--- a/spec/grape/formatter/json_api_pagination_spec.rb
+++ b/spec/grape/formatter/json_api_pagination_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+# class StockOrderResource
+
+RSpec.describe Grape::Formatter::JsonApiPagination do
+  it 'provides pagination links' do
+    resource = double('active_record_resource', :to_ary => [])
+    fake_env = { 'api.endpoint' => double('endpoint', namespace_inheritable: '""') }
+    actual = described_class.call(resource, fake_env)
+    expected = {
+      data: {},
+      links: {}
+    }
+
+    expect(actual).to eq expected
+  end
+end

--- a/spec/grape/formatter/json_api_pagination_spec.rb
+++ b/spec/grape/formatter/json_api_pagination_spec.rb
@@ -4,110 +4,190 @@ require 'spec_helper'
 require 'kaminari'
 
 Merchant = Struct.new(:id, :name)
+Product = Struct.new(:id, :name)
+
+class ProductResource < JSONAPI::Resource
+  attribute :name
+
+  has_one :merchant
+end
 
 class MerchantResource < JSONAPI::Resource
   attribute :name
+
+  has_one :product
 end
 
 RSpec.describe Grape::Formatter::JsonApiPagination do
   let(:base_url) { 'http://localhost:3000' }
+  let(:fake_endpoint) { double('endpoint', namespace_inheritable: base_url) }
+  let(:fake_env) do
+    {
+      'api.endpoint' => fake_endpoint
+    }
+  end
+  let(:resource) do
+    [
+      Merchant.new(12, 'Purton'),
+      Merchant.new(13, 'Anspach')
+    ]
+  end
 
-  context 'when there is no pagination supplied' do
-    it 'provides no pagination links' do
-      resource = [Merchant.new(12, 'Purton')]
-      fake_env = {
-        'api.endpoint' => double('endpoint', namespace_inheritable: base_url)
-      }
-      actual = described_class.call(resource, fake_env)
+  describe 'characterisation spec for the JSONAPI response' do
+    it 'matches the spec' do
       expected = {
-        data: [
+        'data' => [
           {
-            id: '12',
-            type: 'merchants',
-            links: {
-              self: 'http://localhost:3000/merchants/12'
+            'id' => '12',
+            'type' => 'merchants',
+            'links' => {
+              'self' => 'http://localhost:3000/merchants/12'
             },
-            attributes: {
-              name: 'Purton'
+            'attributes' => {
+              'name' => 'Purton'
+            },
+            'relationships' => {
+              'product' => {
+                'links' => {
+                  'self' => 'http://localhost:3000/merchants/12/relationships/product',
+                  'related' => 'http://localhost:3000/merchants/12/product'
+                }
+              }
+            }
+          },
+          {
+            'id' => '13',
+            'type' => 'merchants',
+            'links' => {
+              'self' => 'http://localhost:3000/merchants/13'
+            },
+            'attributes' => {
+              'name' => 'Anspach'
+            },
+            'relationships' => {
+              'product' => {
+                'links' => {
+                  'self' => 'http://localhost:3000/merchants/13/relationships/product',
+                  'related' => 'http://localhost:3000/merchants/13/product'
+                }
+              }
             }
           }
         ]
       }
-
-      expect(JSON.parse(actual)).to eq expected.as_json
+      json = described_class.call(resource, fake_env)
+      expect(JSON.parse(json)).to eq expected
     end
   end
 
-  context 'with a paginated resource supplied' do
-    let(:pagination_links) { JSON.parse(described_class.call(resource, fake_env))["links"] }
+  describe 'pagination' do
+    context 'when there is no pagination supplied' do
+      it 'provides no pagination links' do
+        resource = [Merchant.new(12, 'Purton')]
 
-    context 'when there is only one page' do
-      let(:fake_env) do
-        {
-          'api.endpoint' => double('endpoint', namespace_inheritable: base_url),
-          'REQUEST_URI' => '/merchants?page[number]=1&page[size]=2',
-          'PATH_INFO' => '/merchants',
-          'QUERY_STRING' => 'page[number]=1&page[size]=2'
-        }
-      end
-      let(:resource) do
-        Kaminari.paginate_array(
-          [
-            Merchant.new(12, 'Purton')
-          ]
-        ).page(1).per(2)
-      end
-
-      it 'provides pagination links' do
+        actual = described_class.call(resource, fake_env)
         expected = {
-          self: 'http://localhost:3000/merchants?page[number]=1&page[size]=2',
-          first: 'http://localhost:3000/merchants?page[number]=1&page[size]=2',
-          last: 'http://localhost:3000/merchants?page[number]=1&page[size]=2'
+          data: [
+            {
+              id: '12',
+              type: 'merchants',
+              links: {
+                self: 'http://localhost:3000/merchants/12'
+              },
+              attributes: {
+                name: 'Purton'
+              },
+              relationships: {
+                product: {
+                  links: {
+                    self: 'http://localhost:3000/merchants/12/relationships/product',
+                    related: 'http://localhost:3000/merchants/12/product'
+                  }
+                }
+              }
+            }
+          ]
         }
 
-        expect(pagination_links).to eq expected.as_json
+        expect(JSON.parse(actual)).to eq expected.as_json
       end
     end
 
-    context 'when there are multiple pages' do
-      context 'when we are on the middle page' do
+    context 'with a paginated resource supplied' do
+      let(:pagination_links) do
+        JSON.parse(described_class.call(resource, fake_env))['links']
+      end
+
+      context 'when there is only one page' do
         let(:fake_env) do
           {
-            'api.endpoint' => double('endpoint', namespace_inheritable: base_url),
-            'REQUEST_URI' => '/merchants?page[number]=2&page[size]=2',
+            'api.endpoint' => fake_endpoint,
+            'REQUEST_URI' => '/merchants?page[number]=1&page[size]=2',
             'PATH_INFO' => '/merchants',
-            'QUERY_STRING' => 'page[number]=2&page[size]=2'
+            'QUERY_STRING' => 'page[number]=1&page[size]=2'
           }
         end
         let(:resource) do
           Kaminari.paginate_array(
             [
-              Merchant.new(12, 'Purton'),
-              Merchant.new(13, 'Anspach'),
-              Merchant.new(14, 'Fourpure'),
-              Merchant.new(15, 'Naty'),
-              Merchant.new(16, 'Ranas'),
-              Merchant.new(17, 'Longmans'),
+              Merchant.new(12, 'Purton')
             ]
-          ).page(2).per(2)
+          ).page(1).per(2)
         end
 
-        it 'provides a pagination link for the first page' do
-          expect(pagination_links["first"]).to eq 'http://localhost:3000/merchants?page[number]=1&page[size]=2'
-        end
+        it 'provides pagination links' do
+          expected = {
+            self: 'http://localhost:3000/merchants?page[number]=1&page[size]=2',
+            first: 'http://localhost:3000/merchants?page[number]=1&page[size]=2',
+            last: 'http://localhost:3000/merchants?page[number]=1&page[size]=2'
+          }
 
-        it 'provides a pagination link for the last page' do
-          link = pagination_links["last"]
-          expect(link).to eq 'http://localhost:3000/merchants?page[number]=3&page[size]=2'
+          expect(pagination_links).to eq expected.as_json
         end
+      end
 
-        it 'provides a pagination link for the previous page' do
-          expect(pagination_links["prev"]).to eq 'http://localhost:3000/merchants?page[number]=1&page[size]=2'
-        end
+      context 'when there are multiple pages' do
+        context 'when we are on the middle page' do
+          let(:fake_env) do
+            {
+              'api.endpoint' => fake_endpoint,
+              'REQUEST_URI' => '/merchants?page[number]=2&page[size]=2',
+              'PATH_INFO' => '/merchants',
+              'QUERY_STRING' => 'page[number]=2&page[size]=2'
+            }
+          end
+          let(:resource) do
+            Kaminari.paginate_array(
+              [
+                Merchant.new(12, 'Purton'),
+                Merchant.new(13, 'Anspach'),
+                Merchant.new(14, 'Fourpure'),
+                Merchant.new(15, 'Naty'),
+                Merchant.new(16, 'Ranas'),
+                Merchant.new(17, 'Longmans'),
+              ]
+            ).page(2).per(2)
+          end
 
-        it 'provides a pagination link for the next page' do
-          link = pagination_links["next"]
-          expect(link).to eq 'http://localhost:3000/merchants?page[number]=3&page[size]=2'
+          it 'provides a pagination link for the first page' do
+            expected_link = 'http://localhost:3000/merchants?page[number]=1&page[size]=2'
+            expect(pagination_links['first']).to eq expected_link
+          end
+
+          it 'provides a pagination link for the last page' do
+            expected_link = 'http://localhost:3000/merchants?page[number]=3&page[size]=2'
+            expect(pagination_links['last']).to eq expected_link
+          end
+
+          it 'provides a pagination link for the previous page' do
+            expected_link = 'http://localhost:3000/merchants?page[number]=1&page[size]=2'
+            expect(pagination_links['prev']).to eq expected_link
+          end
+
+          it 'provides a pagination link for the next page' do
+            expected_link = 'http://localhost:3000/merchants?page[number]=3&page[size]=2'
+            expect(pagination_links['next']).to eq expected_link
+          end
         end
       end
     end

--- a/spec/grape/swagger/jsonapi/parser_spec.rb
+++ b/spec/grape/swagger/jsonapi/parser_spec.rb
@@ -1,5 +1,0 @@
-require 'spec_helper'
-
-RSpec.describe Grape::Swagger::Jsonapi::Resources::Parser do
-
-end


### PR DESCRIPTION
This copies the serialiser class in from JSONAPIresource and adds pagination to the output if it's there.

It means that by using this formatter instead of the original one, we get the same response, but with the pagination links too. 

Pagination spec: http://jsonapi.org/format/#fetching-pagination