### PR TITLE
Ops 1472 swagger docs broken

### DIFF
--- a/grape-swagger-jsonapi-resources.gemspec
+++ b/grape-swagger-jsonapi-resources.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "grape", "~> 1.0"
   spec.add_dependency "grape-jsonapi-resources", "~> 0.0.7"
-  spec.add_dependency "grape-swagger", "~> 0.27"
+  spec.add_dependency "grape-swagger", "0.29"
   spec.add_dependency "jsonapi-resources", "~> 0.9.0"
   spec.add_dependency "rails", ">= 4.2" # jsonapi-resources needs this but doesn't declare it
 

--- a/lib/grape/swagger/jsonapi/resources/endpoint_extensions.rb
+++ b/lib/grape/swagger/jsonapi/resources/endpoint_extensions.rb
@@ -18,10 +18,8 @@ module Grape
     end
 
     def json_api_response_object(route)
-      codes = (route.http_codes || route.options[:failure] || [])
-
-      codes = apply_success_codes(route) + codes
-      codes.map! { |x| x.is_a?(Array) ? { code: x[0], message: x[1], model: x[2] } : x }
+      codes = http_codes_from_route(route)
+      codes.map! { |x| x.is_a?(Array) ? { code: x[0], message: x[1], model: x[2], examples: x[3] } : x }
 
       codes.each_with_object({}) do |this_http_code, all_responses|
         this_http_code[:message] ||= ""

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,4 +11,6 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.include Rack::Test::Methods
 end

--- a/spec/swagger_docs_spec.rb
+++ b/spec/swagger_docs_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+
+Product = Struct.new(:id, :name)
+
+class ProductResource < JSONAPI::Resource
+  attribute :name
+end
+
+RSpec.describe "swagger docs" do
+  before :all do
+    module TheApi
+      class SwaggerApi < Grape::API
+        formatter :jsonapi, Grape::Formatter::JsonApiPagination
+        content_type :jsonapi, "application/vnd.api+json"
+        default_format :jsonapi
+        format :jsonapi
+
+        desc "This returns something",
+             headers: {
+               "X-Rate-Limit-Limit" => {
+                 "description" => "The number of allowed requests in the current period",
+                 "type" => "integer"
+               }
+             },
+             entity: ProductResource
+        params do
+          optional :param_x, type: String, desc: "This is a parameter", documentation: { param_type: "query" }
+        end
+        get "/use_headers" do
+          { "declared_params" => declared(params) }
+        end
+
+        add_swagger_documentation
+      end
+    end
+  end
+
+  def app
+    TheApi::SwaggerApi
+  end
+
+  it "send back a 200 response" do
+    get "/swagger_doc"
+    expect(last_response.status).to eq 200
+  end
+end


### PR DESCRIPTION
This was due to a later version of grape-swagger altering the methods that this gem depends on. This sorts them out and adds a spec.